### PR TITLE
Ability to remove affiliate tokens

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ linkerSettings = nil
 let package = Package(
     name: "Playlister",
     platforms: [
-        .macOS(.v10_13)
+        .macOS(.v10_15)
     ],
     products: [
         .executable(name: "playlister", targets: ["Playlister"]),

--- a/Sources/LibPlaylister/LinkStore.swift
+++ b/Sources/LibPlaylister/LinkStore.swift
@@ -9,7 +9,7 @@ import Foundation
 public protocol LinkStore {
     /// Return a URL (possibly interactively) for an item
     /// - Parameter for: item to get the link
-    func link(for: PlaylistItem) throws -> URL?
+    func link(for: PlaylistItem) throws -> URLComponents?
     
     
     /// Update (or set) the link for an item

--- a/Sources/Playlister/Markdown.swift
+++ b/Sources/Playlister/Markdown.swift
@@ -16,6 +16,7 @@ struct Markdown: ParsableCommand {
     
     @Flag(name: [.long, .customShort("r")]) var includeRatings: Bool
     @Flag(name: [.long, .customShort("l")]) var includeLinks: Bool
+    @Flag(name: [.long, .customShort("s")], help: "Attempt to remove affiliate tokens from generated links. Ignored if not including links.") var stripAffiliateTokens: Bool
     
     func run() throws {
         #if os(macOS)
@@ -27,7 +28,7 @@ struct Markdown: ParsableCommand {
         let folder = Folder.current
         let file = try folder.createFile(named: playlistName + ".md")
         let formatter = includeRatings ? FiveStarRatingFormatter() : nil
-        guard let body = list.asMarkdown(ratingFormatter: formatter, usingLinkStore: database) else {
+        guard let body = list.asMarkdown(ratingFormatter: formatter, usingLinkStore: database, stripAffiliateTokens: stripAffiliateTokens) else {
             throw RuntimeError("Unable to generate playlist body.")
         }
         try file.write(body)

--- a/Tests/LibPlaylisterTests/LibraryTests.swift
+++ b/Tests/LibPlaylisterTests/LibraryTests.swift
@@ -116,8 +116,8 @@ class LibraryTests: XCTestCase {
 }
 
 class TestLinkStore: LinkStore {
-    func link(for: PlaylistItem) throws -> URL? {
-        URL(string: "https://greypatterson.me/")
+    func link(for: PlaylistItem) throws -> URLComponents? {
+        URLComponents(string: "https://greypatterson.me")
     }
     
     func link(for: PlaylistItem, url: URL) throws {


### PR DESCRIPTION
Add an argument to the 'md' command to strip out iTunes Affiliate Program affiliate tokens.